### PR TITLE
Explicitly require "bundler"

### DIFF
--- a/lib/jet_black/session.rb
+++ b/lib/jet_black/session.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "bundler"
 require "fileutils"
 require "forwardable"
 require "open3"


### PR DESCRIPTION
- Explicitly require "bundler" to prevent errors in some contexts.

This solves the first of the issues with running tests on the [branch](https://github.com/lpender/bummr/pull/55) that you proposed to merge for bummr.