### PR TITLE
Use open3 for interactive sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- [Internal] Switch `run_interactive` implementation from `PTY.spawn` to `Open3.popen3`
+
 ## v0.7.1
 
 - Fix file descriptor leak in `run_interactive`

--- a/lib/jet_black/terminal_session.rb
+++ b/lib/jet_black/terminal_session.rb
@@ -69,9 +69,6 @@ module JetBlack
       until stdout_io.eof? do
         chunked_stdout << stdout_io.readline
       end
-    rescue Errno::EIO => e # https://github.com/ruby/ruby/blob/57fb2199059cb55b632d093c2e64c8a3c60acfbb/ext/pty/pty.c#L521
-      # TODO: Evaluate if this rescue is still required with Open3.popen3
-      warn("Rescued #{e.message}") if ENV.key?("DEBUG")
     ensure
       stdout_io.close
     end

--- a/spec/lib/jet_black/terminal_session_spec.rb
+++ b/spec/lib/jet_black/terminal_session_spec.rb
@@ -1,8 +1,8 @@
 require "jet_black/terminal_session"
 
-RSpec.describe JetBlack::TerminalSession, pending: "Failing on Linux" do
+RSpec.describe JetBlack::TerminalSession do
   describe "#wait_for_finish" do
-    xit "closes the input, stdout and stderr IO" do
+    xit "closes the input, stdout and stderr IO", pending: "Failing on Linux" do
       open_and_wait = Proc.new do
         described_class.new("echo foo", env: {}, directory: __dir__).wait_for_finish
       end
@@ -12,12 +12,22 @@ RSpec.describe JetBlack::TerminalSession, pending: "Failing on Linux" do
   end
 
   describe "#end_session" do
-    xit "closes the input, stdout and stderr IO" do
+    xit "closes the input, stdout and stderr IO", pending: "Failing on Linux" do
       open_and_end = Proc.new do
         described_class.new("echo foo", env: {}, directory: __dir__).end_session
       end
 
       expect(open_and_end).to_not change { open_file_descriptor_count }
+    end
+
+    it "gracefully handles processes which are already dead" do
+      session = described_class.new("sleep 30", env: {}, directory: __dir__)
+
+      # Terminate process ourselves, so the session encounters Errno::ESRCH
+      Process.kill("INT", session.pid)
+
+      expect { session.end_session }.to_not raise_exception
+      expect(session.exit_status).to eq(Signal.list["INT"])
     end
   end
 

--- a/spec/lib/jet_black/terminal_session_spec.rb
+++ b/spec/lib/jet_black/terminal_session_spec.rb
@@ -2,7 +2,7 @@ require "jet_black/terminal_session"
 
 RSpec.describe JetBlack::TerminalSession do
   describe "#wait_for_finish" do
-    xit "closes the input, stdout and stderr IO", pending: "Failing on Linux" do
+    it "closes the input, stdout and stderr IO" do
       open_and_wait = Proc.new do
         described_class.new("echo foo", env: {}, directory: __dir__).wait_for_finish
       end
@@ -12,7 +12,7 @@ RSpec.describe JetBlack::TerminalSession do
   end
 
   describe "#end_session" do
-    xit "closes the input, stdout and stderr IO", pending: "Failing on Linux" do
+    it "closes the input, stdout and stderr IO" do
       open_and_end = Proc.new do
         described_class.new("echo foo", env: {}, directory: __dir__).end_session
       end


### PR DESCRIPTION
Replaces `PTY.spawn` with `Open3.popen3` due to issues with the former on Ruby 3.x